### PR TITLE
Add hx3compat to run tests on Haxe 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
   - mkdir haxelib
   - haxelib setup haxelib
   - haxelib install hxcpp > /dev/null
+  - haxelib install hx3compat > /dev/null
 before_script:
   - cd $TRAVIS_BUILD_DIR
 script:

--- a/test/compile.hxml
+++ b/test/compile.hxml
@@ -1,5 +1,6 @@
 -cp .
 -cp ../src
+-lib hx3compat
 -main TestMain
 -debug
 -cpp ../bin/test
@@ -8,6 +9,7 @@
 
 -cp .
 -cp ../src
+-lib hx3compat
 -main TestMain
 -debug
 -neko ../bin/test/TestMain.n


### PR DESCRIPTION
`./test.sh` was failing for me in my Haxe 4 dev environment. The solution is to install the hx3compat library which provides the deprecated Haxe unit testing module.